### PR TITLE
fix compatibility when used via rubocop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+- Fix compatibility when used via rubocop
+  [569](https://github.com/standardrb/standard/issues/569)
+
 ## [1.0.1]
 
 - Remove erroneous file

--- a/lib/standard/custom.rb
+++ b/lib/standard/custom.rb
@@ -1,7 +1,10 @@
+require "rubocop"
 require "lint_roller"
 
 require_relative "custom/version"
 require_relative "custom/plugin"
+
+require_relative "cop/block_single_line_braces"
 
 module Standard
   module Custom

--- a/lib/standard/custom/plugin.rb
+++ b/lib/standard/custom/plugin.rb
@@ -18,8 +18,6 @@ module Standard::Custom
     end
 
     def rules(context)
-      require_relative "../cop/block_single_line_braces"
-
       LintRoller::Rules.new(
         type: :path,
         config_format: :rubocop,


### PR DESCRIPTION
Fixes a loading issue when standard configs are used via rubocop:
See details here: https://github.com/standardrb/standard/issues/569