### PR TITLE
Ruby version support bump to 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: [2.7, '3.0', 3.1, 3.2]
+        ruby-version:
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
 
     runs-on: ${{ matrix.os }}
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,52 +9,56 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    json (2.6.3)
+    json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
-    m (1.6.1)
+    m (1.6.2)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
-    method_source (1.0.0)
-    minitest (5.18.1)
-    parallel (1.23.0)
-    parser (3.2.2.3)
+    method_source (1.1.0)
+    minitest (5.23.1)
+    parallel (1.25.1)
+    parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
-    racc (1.7.1)
+    racc (1.8.0)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.8.1)
-    rexml (3.2.5)
-    rubocop (1.52.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.0)
+      strscan
+    rubocop (1.64.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
-      parser (>= 3.2.1.0)
-    rubocop-performance (1.18.0)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    standard (1.30.1)
+    standard (1.37.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.52.0)
+      rubocop (~> 1.64.0)
       standard-custom (~> 1.0.0)
-      standard-performance (~> 1.1.0)
-    standard-performance (1.1.1)
+      standard-performance (~> 1.4)
+    standard-performance (1.4.0)
       lint_roller (~> 1.1)
-      rubocop-performance (~> 1.18.0)
-    unicode-display_width (2.4.2)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -65,4 +69,4 @@ DEPENDENCIES
   standard-custom!
 
 BUNDLED WITH
-   2.4.10
+   2.5.13

--- a/standard-custom.gemspec
+++ b/standard-custom.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Plugin containing implementations of custom cops that are bundled as defaults in Standard Ruby"
   spec.homepage = "https://github.com/standardrb/standard-custom"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Background: https://github.com/standardrb/standard-performance/pull/26#issuecomment-2171659693

Also needed some misc Gemfile.lock updates locally to properly bundle/test, lose deprecations, etc.