### PR TITLE
Version bump bundler itself and dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       rake (>= 0.9.2.2)
     method_source (1.1.0)
     minitest (5.25.1)
-    parallel (1.25.1)
+    parallel (1.26.3)
     parser (3.3.5.1)
       ast (~> 2.4.1)
       racc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,4 +69,4 @@ DEPENDENCIES
   standard-custom!
 
 BUNDLED WITH
-   2.5.13
+   2.5.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,10 +18,10 @@ GEM
     method_source (1.1.0)
     minitest (5.23.1)
     parallel (1.25.1)
-    parser (3.3.3.0)
+    parser (3.3.5.1)
       ast (~> 2.4.1)
       racc
-    racc (1.8.0)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    json (2.7.2)
+    json (2.7.5)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
     m (1.6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
     method_source (1.1.0)
-    minitest (5.23.1)
+    minitest (5.25.1)
     parallel (1.25.1)
     parser (3.3.5.1)
       ast (~> 2.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.21.0)
     strscan (3.1.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
   arm64-darwin-22


### PR DESCRIPTION
Opening this JUST in `-custom` for starters, but if there's general head nodding here I'll open analagous PRs in the other repos.

General motivation here is to bump things sufficiently to get rid of various gem/dep warnings about ruby 3.5 changes. In this PR I bumped everything *except* any standard- or rubocop- related gems.
